### PR TITLE
Resolve Retraceur versions dynamically from GitHub Atom feed

### DIFF
--- a/src/download.ts
+++ b/src/download.ts
@@ -12,7 +12,7 @@ import os from 'os';
 import path from 'path';
 import unzipper from 'unzipper';
 import getRetraceurVersionsPath from './get-retraceur-versions-path.js';
-import { getRetraceurDownloadUrl, getRetraceurVersion } from './retraceur-versions.js';
+import { getRetraceurDownloadUrl, resolveRetraceurVersion } from './retraceur-versions.js';
 import { output } from './output.js';
 
 const { https } = followRedirects;
@@ -27,7 +27,7 @@ function httpsGet( url: string, callback: ( response: IncomingMessage ) => void 
 	const options: any = {};
 
 	if ( proxy ) {
-		// Support proxy basique via l'agent Node.js natif (v2 : hpagent)
+		// If a proxy is set, use it for the request.
 		options.headers = { 'User-Agent': 'bacasable/1.0.0' };
 	}
 
@@ -50,7 +50,7 @@ async function downloadFileAndUnzip( {
 	checkFinalPath: string;
 	itemName: string;
 } ): Promise<DownloadFileAndUnzipResult> {
-	// Vérifier si déjà téléchargé
+	// Check whether the final folder already exists and is not empty. If so, skip the download.
 	if (
 		fs.existsSync( checkFinalPath ) &&
 		fs.readdirSync( checkFinalPath ).length > 0
@@ -111,27 +111,29 @@ async function downloadFileAndUnzip( {
 }
 
 /**
- * Télécharger Retraceur depuis GitHub et retourner le chemin d'installation.
+ * Download and extract Retraceur for bacÀsable.
  *
- * @param version - La version de Retraceur à télécharger (défaut: 'latest')
- * @returns Le chemin vers l'installation de Retraceur
+ * @since 1.0.0
+ *
+ * @param version - The version tag to download (e.g., '1.2.3', 'trunk').
+ * @returns The path to the installed Retraceur.
  */
 export async function downloadRetraceur( version: string = 'latest' ): Promise<string> {
-	const versionInfo = getRetraceurVersion( version );
+	const resolvedTag = await resolveRetraceurVersion( version );
 
 	// Use real tag instead of alias (ex: "latest")
-	const finalFolder = path.join( getRetraceurVersionsPath(), versionInfo.tag );
+    const finalFolder = path.join( getRetraceurVersionsPath(), resolvedTag );
 	const tempFolder = os.tmpdir();
 
 	const { downloaded, statusCode } = await downloadFileAndUnzip( {
-		url: getRetraceurDownloadUrl( version ),
+		url: getRetraceurDownloadUrl( resolvedTag ),
 		destinationFolder: tempFolder,
 		checkFinalPath: finalFolder,
-		itemName: `Retraceur ${ versionInfo.tag }`,
+		itemName: `Retraceur ${ resolvedTag }`,
 	} );
 
 	if ( downloaded ) {
-		const extractedFolderName = `coeur-${ versionInfo.tag }`;
+		const extractedFolderName = `coeur-${ resolvedTag }`;
 		const extractedPath = path.join( tempFolder, extractedFolderName );
 
 		if ( ! fs.existsSync( extractedPath ) ) {
@@ -140,18 +142,18 @@ export async function downloadRetraceur( version: string = 'latest' ): Promise<s
 			process.exit( 1 );
 		}
 
-		// Créer le dossier parent si nécessaire
+		// Ensure the final folder exists before moving the extracted files.
 		fs.ensureDirSync( path.dirname( finalFolder ) );
 
-		// Déplacer vers le dossier final
+		// Move the extracted folder to the final destination, overwriting if it already exists.
 		fs.moveSync( extractedPath, finalFolder, {
 			overwrite: true,
 		} );
 
-		output?.log( `Retraceur ${ versionInfo.tag } downloaded to ${ finalFolder }` );
+		output?.log( `Retraceur ${ resolvedTag } downloaded to ${ finalFolder }` );
 	} else if ( 404 === statusCode ) {
 		output?.log(
-			`Retraceur ${ versionInfo.tag } not found. Check https://github.com/retraceur/coeur/releases for available versions.`
+			`Retraceur ${ resolvedTag } not found. Check https://github.com/retraceur/coeur/releases for available versions.`
 		);
 		process.exit( 1 );
 	}

--- a/src/download.ts
+++ b/src/download.ts
@@ -27,7 +27,7 @@ function httpsGet( url: string, callback: ( response: IncomingMessage ) => void 
 	const options: any = {};
 
 	if ( proxy ) {
-		// If a proxy is set, use it for the request.
+		// Basic proxy support via the native Node.js agent (v2: hpagent).
 		options.headers = { 'User-Agent': 'bacasable/1.0.0' };
 	}
 
@@ -142,7 +142,7 @@ export async function downloadRetraceur( version: string = 'latest' ): Promise<s
 			process.exit( 1 );
 		}
 
-		// Ensure the final folder exists before moving the extracted files.
+		// Create the parent folder if necessary.
 		fs.ensureDirSync( path.dirname( finalFolder ) );
 
 		// Move the extracted folder to the final destination, overwriting if it already exists.

--- a/src/get-bacasable-path.ts
+++ b/src/get-bacasable-path.ts
@@ -12,6 +12,10 @@ import getBacAsableTmpPath from './get-bacasable-tmp-path';
 
 /**
  * The full path to the hidden WP Now folder in the user's home directory.
+ *
+ * @since 0.9.0
+ *
+ * @returns The full path to the hidden bacÀsable folder.
  */
 export default function getBacAsablePath() {
 	if (process.env.NODE_ENV !== 'test') {

--- a/src/get-bacasable-tmp-path.ts
+++ b/src/get-bacasable-tmp-path.ts
@@ -9,7 +9,11 @@ import path from 'path';
 import os from 'os';
 
 /**
- * The full path to the hidden WP Now folder in the user's tmp directory.
+ * The full path to the hidden bacÀsable folder in the user's tmp directory.
+ *
+ * @since 0.9.0
+ *
+ * @returns The full path to the hidden bacÀsable folder in the tmp directory.
  */
 export default function getBacAsableTmpPath() {
 	const tmpDirectory = os.tmpdir();

--- a/src/get-retraceur-versions-path.ts
+++ b/src/get-retraceur-versions-path.ts
@@ -12,6 +12,7 @@ import getBacAsablePath from './get-bacasable-path';
  * The path where Retraceur zip files will be unzipped and stored within the bacÀsable folder.
  *
  * @since 0.9.0
+ *
  * @returns {string} The path to the Retraceur versions directory.
  */
 export default function getRetraceurVersionsPath() {

--- a/src/github-codespaces.ts
+++ b/src/github-codespaces.ts
@@ -13,9 +13,14 @@ export const isGitHubCodespace = Boolean(
 		process.env.GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN
 );
 
-/*
+/**
  * Returns the URL in the current GitHub Codespace
  * e.g: https://sejas-fluffy-space-eureka-wrj7r95qhvq4x-8881.preview.app.github.dev
+ *
+ * @since 0.9.0
+ *
+ * @param port - The port number to include in the URL.
+ * @returns The full URL for the specified port in the GitHub Codespace.
  */
 export function getCodeSpaceURL(port: number): string {
 	return `https://${process.env.CODESPACE_NAME}-${port}.${process.env.GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN}`;

--- a/src/main.ts
+++ b/src/main.ts
@@ -39,7 +39,13 @@ export interface BacAsableServer {
 }
 
 /**
- * Détecter le mode selon le contenu du répertoire
+ * Detect the mode based on the project path and options.
+ *
+ * @since 1.0.0
+ *
+ * @param projectPath - The path to the project.
+ * @param options - The options provided by the user.
+ * @returns The detected mode.
  */
 function inferMode( projectPath: string, options: BacAsableOptions ): Mode {
 	// Mode forcé via option CLI
@@ -67,7 +73,14 @@ function inferMode( projectPath: string, options: BacAsableOptions ): Mode {
 }
 
 /**
- * Construire les mounts selon le mode
+ * Build the mounts for the Docker container based on the mode and paths.
+ *
+ * @since 1.0.0
+ *
+ * @param mode - The detected mode.
+ * @param projectPath - The path to the project.
+ * @param retraceurPath - The path to the Retraceur installation.
+ * @returns An array of mount objects with hostPath and vfsPath.
  */
 function buildMounts(
 	mode: Mode,
@@ -75,7 +88,7 @@ function buildMounts(
 	retraceurPath: string
 ): Array<{ hostPath: string; vfsPath: string }> {
 	const mounts = [
-		// Retraceur toujours monté à la racine
+		// Retraceur is always mounted to root `/wordpress` in the container
 		{
 			hostPath: retraceurPath,
 			vfsPath: '/wordpress',
@@ -114,7 +127,12 @@ function buildMounts(
 }
 
 /**
- * Démarrer bacÀsable
+ * Start bacÀsable
+ *
+ * @since 1.0.0
+ *
+ * @param options - The options for starting bacÀsable.
+ * @returns The server information including URL and port.
  */
 export async function startBacasable( options: BacAsableOptions ): Promise<BacAsableServer> {
 	const projectPath = path.resolve( options.path || process.cwd() );
@@ -127,22 +145,22 @@ export async function startBacasable( options: BacAsableOptions ): Promise<BacAs
 	output?.log( `php: ${ options.php || DEFAULT_PHP_VERSION }` );
 	output?.log( `retraceur: ${ options.retraceur || DEFAULT_RETRACEUR_VERSION }` );
 
-	// Déterminer le chemin Retraceur
+	// Used to determine Retraceur path (local or downloaded).
 	let retraceurPath: string;
 
 	if ( mode === 'retraceur' ) {
-		// Installation locale : pas de téléchargement
+		// Local Retraceur installation is used directly.
 		output?.log( '✅ Using local Retraceur installation' );
 		retraceurPath = projectPath;
 	} else {
-		// Télécharger Retraceur si nécessaire
+		// Download Retraceur if not already downloaded.
 		retraceurPath = await downloadRetraceur( options.retraceur || DEFAULT_RETRACEUR_VERSION );
 	}
 
-	// Construire les mounts
+	// Build the mounts.
 	const mounts = buildMounts( mode, projectPath, retraceurPath );
 
-	// Intercepter stdout pour remplacer les messages WordPress
+	// Intercept stdout to replace "WordPress" with "Retraceur" in the output.
 	const originalWrite = process.stdout.write.bind( process.stdout );
 	( process.stdout.write as any ) = ( chunk: any, ...args: any[] ) => {
 		// Regex pour matcher un code ANSI optionnel
@@ -163,7 +181,7 @@ export async function startBacasable( options: BacAsableOptions ): Promise<BacAs
 		return originalWrite( chunk, ...args );
 	};
 
-	// Lancer runCLI
+	// Launch the CLI with the specified options.
 	const server = await runCLI( {
 		command: 'server',
 		php: ( options.php || DEFAULT_PHP_VERSION ) as any,
@@ -172,10 +190,10 @@ export async function startBacasable( options: BacAsableOptions ): Promise<BacAs
 		port,
 	} );
 
-	// Restaurer stdout
+	// Restore the original stdout.write function to avoid affecting other parts of the application.
 	process.stdout.write = originalWrite;
 
-	// Déterminer l'URL (Codespaces ou local)
+	// Determine the URL (Codespaces or local).
 	const url = isGitHubCodespace
 		? getCodeSpaceURL( port )
 		: server.serverUrl;

--- a/src/main.ts
+++ b/src/main.ts
@@ -48,7 +48,7 @@ export interface BacAsableServer {
  * @returns The detected mode.
  */
 function inferMode( projectPath: string, options: BacAsableOptions ): Mode {
-	// Mode forcé via option CLI
+	// Forced mode via CLI option.
 	if ( options.mode ) {
 		return options.mode;
 	}
@@ -88,7 +88,7 @@ function buildMounts(
 	retraceurPath: string
 ): Array<{ hostPath: string; vfsPath: string }> {
 	const mounts = [
-		// Retraceur is always mounted to root `/wordpress` in the container
+		// Retraceur is always mounted at the root.
 		{
 			hostPath: retraceurPath,
 			vfsPath: '/wordpress',
@@ -160,7 +160,7 @@ export async function startBacasable( options: BacAsableOptions ): Promise<BacAs
 	// Build the mounts.
 	const mounts = buildMounts( mode, projectPath, retraceurPath );
 
-	// Intercept stdout to replace "WordPress" with "Retraceur" in the output.
+	// Intercept `stdout` to replace WP trademark with "Retraceur" in the output.
 	const originalWrite = process.stdout.write.bind( process.stdout );
 	( process.stdout.write as any ) = ( chunk: any, ...args: any[] ) => {
 		// Regex pour matcher un code ANSI optionnel
@@ -190,7 +190,7 @@ export async function startBacasable( options: BacAsableOptions ): Promise<BacAs
 		port,
 	} );
 
-	// Restore the original stdout.write function to avoid affecting other parts of the application.
+	// Restore the original `stdout.write` function to avoid affecting other parts of the application.
 	process.stdout.write = originalWrite;
 
 	// Determine the URL (Codespaces or local).

--- a/src/retraceur-versions.ts
+++ b/src/retraceur-versions.ts
@@ -1,103 +1,137 @@
 /**
  * Retraceur versions information and utilities.
  *
- * This module defines the available versions of Retraceur, their corresponding PHP versions, and release dates.
- * It also provides utility functions to retrieve version information and construct download URLs for specific versions.
+ * Versions are resolved dynamically from the GitHub releases Atom feed.
  *
  * @module retraceur-versions
- * @since 0.9.0
+ * @since 1.0.0
  */
 
-export interface RetraceurVersion {
-	tag: string;
-	phpVersion: string;
-	releaseDate: string;
-}
+const RETRACEUR_RELEASES_ATOM_URL = 'https://github.com/retraceur/coeur/releases.atom';
+const RETRACEUR_TRUNK_URL = 'https://github.com/retraceur/coeur/archive/refs/heads/trunk.zip';
+const RETRACEUR_TAG_URL = ( tag: string ) =>
+	`https://github.com/retraceur/coeur/archive/refs/tags/${ tag }.zip`;
 
-export const RETRACEUR_VERSIONS: Record<string, RetraceurVersion> = {
-	'trunk': {
-		tag: 'trunk',
-		phpVersion: '8.3',
-		releaseDate: 'rolling'
-	},
-	'latest': {
-		tag: '4.2.0',
-		phpVersion: '8.3',
-		releaseDate: '2026-03-14'
-	},
-	'4.2.0': {
-		tag: '4.2.0',
-		phpVersion: '8.3',
-		releaseDate: '2026-03-14'
-	},
-	'4.1.0': {
-		tag: '4.1.0',
-		phpVersion: '8.3',
-		releaseDate: '2026-03-14'
-	},
-	'4.0.0': {
-		tag: '4.0.0',
-		phpVersion: '8.3',
-		releaseDate: '2026-03-14'
-	},
-	'3.2.0': {
-		tag: '3.2.0',
-		phpVersion: '8.2',
-		releaseDate: '2026-03-14'
-	},
-	'3.1.0': {
-		tag: '3.1.0',
-		phpVersion: '8.2',
-		releaseDate: '2026-03-14'
-	},
-	'3.0.0': {
-		tag: '3.0.0',
-		phpVersion: '8.2',
-		releaseDate: '2026-03-01'
-	},
-	'2.0.1': {
-		tag: '2.0.1',
-		phpVersion: '8.2',
-		releaseDate: '2025-10-01'
-	},
-	'2.0.0': {
-		tag: '2.0.0',
-		phpVersion: '8.2',
-		releaseDate: '2025-08-15'
+/**
+ * Fetch available versions from the GitHub releases Atom feed.
+ * Returns an ordered list of tags (most recent first).
+ *
+ * @since 1.0.0
+ *
+ * @returns An array of version tags (e.g., ['1.2.3', '1.2.2', '1.2.1']).
+ * @throws If there is an error fetching or parsing the feed.
+ */
+export async function fetchAvailableVersions(): Promise<string[]> {
+	try {
+		const response = await fetch( RETRACEUR_RELEASES_ATOM_URL );
+
+		if ( ! response.ok ) {
+			throw new Error( `Failed to fetch releases feed: ${ response.status }` );
+		}
+
+		const xml = await response.text();
+
+		// Extraire les tags depuis les balises <id>
+		// Format : tag:github.com,2008:Repository/882273877/4.2.0
+		const matches = xml.matchAll(
+			/<id>tag:github\.com,2008:Repository\/\d+\/([^<]+)<\/id>/g
+		);
+
+		return Array.from( matches, ( m ) => m[ 1 ] );
+	} catch ( error ) {
+		throw new Error( `Could not fetch Retraceur versions: ${ error }` );
 	}
-};
-
-export function getRetraceurVersion( requested: string ): RetraceurVersion {
-	return RETRACEUR_VERSIONS[ requested ] || RETRACEUR_VERSIONS[ 'latest' ];
 }
 
-export async function resolveRetraceurVersion( retraceurVersion: string ) {
-	const versionInfo = getRetraceurVersion( retraceurVersion );
+/**
+ * Resolve 'latest' to the most recent stable version from the feed.
+ * Skips pre-releases (beta, RC, alpha) unless no stable version is found.
+ *
+ * @since 1.0.0
+ *
+ * @returns The resolved latest version tag.
+ * @throws If no versions are found in the feed.
+ */
+export async function resolveLatestVersion(): Promise<string> {
+	const versions = await fetchAvailableVersions();
 
-	if ( 'trunk' === versionInfo.tag ) {
-		return {
-			resolvedRetraceurVersion: versionInfo.tag,
-			isDeveloperBuild: true,
-		};
+	// Chercher la première version stable (sans suffixe beta/RC/alpha)
+	const stable = versions.find(
+		( v ) => ! /-(beta|rc|alpha)/i.test( v )
+	);
+
+	if ( stable ) {
+		return stable;
 	}
 
-	return {
-		resolvedRetraceurVersion: retraceurVersion,
-		isDeveloperBuild: false,
-	};
-}
-
-export function getRetraceurDownloadUrl( version: string ): string {
-	const versionInfo = getRetraceurVersion( version );
-	const tag = versionInfo.tag;
-
-	if ( 'trunk' === tag ) {
-		return 'https://github.com/retraceur/coeur/archive/refs/heads/trunk.zip';
+	// Si aucune version stable, prendre la première disponible
+	if ( versions.length > 0 ) {
+		return versions[ 0 ];
 	}
 
-	return `https://github.com/retraceur/coeur/archive/refs/tags/${tag}.zip`;
+	throw new Error( 'No Retraceur versions found in the releases feed.' );
 }
 
-export function listAvailableVersions(): string[] {
-	return Object.keys( RETRACEUR_VERSIONS );
+/**
+ * Validate that a given version tag exists in the GitHub releases feed.
+ *
+ * @since 1.0.0
+ *
+ * @param version - The version tag to validate (e.g., '1.2.3', 'trunk').
+ * @returns True if the version exists, false otherwise.
+ * @throws If there is an error fetching the versions feed.
+ */
+export async function validateVersion( version: string ): Promise<boolean> {
+	const versions = await fetchAvailableVersions();
+	return versions.includes( version );
+}
+
+/**
+ * Resolve a version string to a concrete tag.
+ * - 'latest' → most recent stable release (from feed).
+ * - 'trunk'  → development branch.
+ * - anything else → validated against the feed.
+ *
+ * @since 1.0.0
+ * @param version - The version string to resolve ('latest', 'trunk', or a specific tag).
+ * @returns The resolved version tag.
+ * @throws If the specified version does not exist.
+ */
+export async function resolveRetraceurVersion( version: string = 'latest' ): Promise<string> {
+	if ( version === 'trunk' ) {
+		return 'trunk';
+	}
+
+	if ( version === 'latest' ) {
+		return await resolveLatestVersion();
+	}
+
+	// Valider que la version demandée existe
+	const isValid = await validateVersion( version );
+
+	if ( ! isValid ) {
+		const available = await fetchAvailableVersions();
+		throw new Error(
+			`Retraceur version "${ version }" not found.\n` +
+			`Available versions: ${ [ 'trunk', 'latest', ...available ].join( ', ' ) }`
+		);
+	}
+
+	return version;
+}
+
+/**
+ * Get the download URL for a resolved version tag.
+ *
+ * @since 1.0.0
+ *
+ * @param tag - The resolved version tag (e.g., '1.2.3', 'trunk').
+ * @returns The download URL for the specified version.
+ */
+export function getRetraceurDownloadUrl( tag: string ): string {
+	if ( tag === 'trunk' ) {
+		return RETRACEUR_TRUNK_URL;
+	}
+
+	return RETRACEUR_TAG_URL( tag );
 }

--- a/src/retraceur-versions.ts
+++ b/src/retraceur-versions.ts
@@ -31,7 +31,7 @@ export async function fetchAvailableVersions(): Promise<string[]> {
 
 		const xml = await response.text();
 
-		// Extraire les tags depuis les balises <id>
+		// Extract version numbers from the <id> tags.
 		// Format : tag:github.com,2008:Repository/882273877/4.2.0
 		const matches = xml.matchAll(
 			/<id>tag:github\.com,2008:Repository\/\d+\/([^<]+)<\/id>/g
@@ -55,7 +55,7 @@ export async function fetchAvailableVersions(): Promise<string[]> {
 export async function resolveLatestVersion(): Promise<string> {
 	const versions = await fetchAvailableVersions();
 
-	// Chercher la première version stable (sans suffixe beta/RC/alpha)
+	// Search for the first stable version (without the beta/RC/alpha suffix).
 	const stable = versions.find(
 		( v ) => ! /-(beta|rc|alpha)/i.test( v )
 	);
@@ -64,7 +64,7 @@ export async function resolveLatestVersion(): Promise<string> {
 		return stable;
 	}
 
-	// Si aucune version stable, prendre la première disponible
+	// If there is no stable version, use the first available one.
 	if ( versions.length > 0 ) {
 		return versions[ 0 ];
 	}


### PR DESCRIPTION
- Remove static RETRACEUR_VERSIONS mapping
- Fetch available versions from releases.atom
- Resolve 'latest' to most recent stable release
- Skip pre-releases (beta/RC/alpha) for 'latest'
- Validate requested version before download
- Clear error message with available versions on invalid input"

Fixes #13