### PR TITLE
feat: Enable debug constants by default

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -181,6 +181,18 @@ export async function startBacasable( options: BacAsableOptions ): Promise<BacAs
 		return originalWrite( chunk, ...args );
 	};
 
+	const retraceurConstants = {
+		WP_DEBUG: true,
+		WP_SCRIPT_DEBUG: true,
+		WP_DEBUG_LOG: false,
+		WP_DEBUG_DISPLAY: true,
+	};
+
+	if ( mode === 'retraceur' || mode === 'wp-content') {
+		retraceurConstants.WP_DEBUG_LOG = true;
+		retraceurConstants.WP_DEBUG_DISPLAY = false;
+	}
+
 	// Launch the CLI with the specified options.
 	const server = await runCLI( {
 		command: 'server',
@@ -188,6 +200,10 @@ export async function startBacasable( options: BacAsableOptions ): Promise<BacAs
 		wordpressInstallMode: 'do-not-attempt-installing',
 		'mount-before-install': mounts,
 		port,
+		blueprint: {
+			constants: retraceurConstants,
+			steps: [],
+		},
 	} );
 
 	// Restore the original `stdout.write` function to avoid affecting other parts of the application.


### PR DESCRIPTION
Enable WP debug constants for all modes via `blueprint.constants`:
- `WP_DEBUG: true`
- `WP_SCRIPT_DEBUG: true`
- `WP_DEBUG_DISPLAY: true` (`false` in retraceur/wp-content modes)
- `WP_DEBUG_LOG: false` (`true` in retraceur/wp-content modes)

In retraceur and wp-content modes, errors are written to the `debug.log` file (synchronized with the local wp-content directory) rather than displayed on screen, which is more suitable for active development.