### PR TITLE
Add email interception for development

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -202,7 +202,36 @@ export async function startBacasable( options: BacAsableOptions ): Promise<BacAs
 		port,
 		blueprint: {
 			constants: retraceurConstants,
-			steps: [],
+			steps: [
+				{
+					step: 'writeFile',
+					path: '/wordpress/wp-content/mu-plugins/bacasable-mail-interceptor.php',
+					data: `<?php
+					/**
+					 * bacÀsable Mail Interceptor
+					 * Intercepts all emails and writes them to wp-content/bacasable-emails.json.
+					 */
+					add_filter( 'wp_mail', function( array $args ): array {
+						$log_file = WP_CONTENT_DIR . '/bacasable-emails.json';
+						$emails   = file_exists( $log_file )
+							? json_decode( file_get_contents( $log_file ), true ) ?? []
+							: [];
+
+						$emails[] = [
+							'date'    => date( 'c' ),
+							'to'      => $args['to'],
+							'subject' => $args['subject'],
+							'message' => $args['message'],
+							'headers' => $args['headers'],
+						];
+
+						file_put_contents( $log_file, json_encode( $emails, JSON_PRETTY_PRINT ) );
+
+						// Make sure the email is not sent to the actual recipient.
+						return array_merge( $args, [ 'to' => '' ] );
+					} );`,
+				},
+			],
 		},
 	} );
 


### PR DESCRIPTION
Adds a mail interceptor mu-plugin injected via Blueprint that captures all outgoing emails during development instead of sending them.

## How it works
A mu-plugin is injected at startup via blueprint.steps using a writeFile step. It hooks into `wp_mail` to intercept every outgoing email and appends it to a `bacasable-emails.json` file in `wp-content/`.
Since `wp-content/` is mounted to the local filesystem, the file is automatically synchronized on disk and readable with any text editor or JSON viewer.
Real email delivery is blocked by replacing the recipient with an empty string before Retraceur attempts to send.
Captured data

Each intercepted email is stored as a JSON object :

```json
{
  "date": "2026-08-15T10:30:00+00:00",
  "to": "admin@example.com",
  "subject": "Your password has been reset",
  "message": "...",
  "headers": []
}
```

## Notes

- Works in all modes (plugin, theme, wp-content, retraceur)
- No external dependency required
- The `bacasable-emails.json` file is created on the first intercepted email
- Paves the way for a future web UI (`/__bacasable/emails`) in a later iteration